### PR TITLE
Add docker_mlx_cpp — Metal GPU access from Docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ An awesome list dedicated to the [MLX library](https://github.com/ml-explore/mlx
 - [AutoMLX](https://github.com/wsvn53/AutoMLX): An easy-to-use LLMs inference tool for quickly loading models accelerated by the Apple MLX framework on Mac devices, and providing a simple and compatible API interface for integration with other LLMs tools.
 - [mlx-omni-server](https://github.com/madroidmaq/mlx-omni-server): MLX Omni Server is a local inference server powered by Apple's MLX framework, specifically designed for Apple Silicon (M-series) chips. It implements OpenAI-compatible API endpoints, enabling seamless integration with existing OpenAI SDK clients while leveraging the power of local ML inference.
 - [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX): OpenAI-compatible LLM inference server for Apple Silicon. 2-4x faster than Ollama with full tool calling, reasoning separation, and prompt caching.
+- [docker_mlx_cpp](https://github.com/RobotFlow-Labs/docker_mlx_cpp): The NVIDIA Container Toolkit for Mac. Give any Docker container full Apple Silicon Metal GPU access — 100+ GPU operations, LLM inference, training, image gen, audio, embeddings. One-line install.
 
 ## Demo
 


### PR DESCRIPTION
## What

Adding [docker_mlx_cpp](https://github.com/RobotFlow-Labs/docker_mlx_cpp) to the Libraries and Tools section.

## About docker_mlx_cpp

The NVIDIA Container Toolkit equivalent for Mac. Gives any Docker container full Apple Silicon Metal GPU access:

- **107 GPU operations** across 15 categories (arithmetic, linear algebra, FFT, convolutions, attention, normalization, etc.)
- **LLM inference** (50+ architectures via mlx-lm)
- **VLM** (vision-language models via mlx-vlm)
- **Training** (LoRA/QLoRA via mlx-lm tuner)
- **Audio** (Whisper STT + Kokoro TTS via mlx-audio)
- **Image generation** (FLUX via mflux)
- **Embeddings** (via mlx-embeddings)

One-line install: `curl -fsSL https://raw.githubusercontent.com/RobotFlow-Labs/docker_mlx_cpp/main/install.sh | bash`

All operations tested on Apple M5 (107/108 passing, ~95 TFLOPS). MIT licensed.