### PR TITLE
Add mlx-teacache and mlx-taef to Libraries and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ An awesome list dedicated to the [MLX library](https://github.com/ml-explore/mlx
 - [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX): OpenAI-compatible LLM inference server for Apple Silicon. 2-4x faster than Ollama with full tool calling, reasoning separation, and prompt caching.
 
 - [docker_mlx_cpp](https://github.com/RobotFlow-Labs/docker_mlx_cpp) - The NVIDIA Container Toolkit for Mac. Give any Docker container full Metal GPU access. 107+ GPU operations via MLX.
+- [mlx-teacache](https://github.com/IonDen/mlx-teacache): TeaCache step-skipping wrapper for mflux FLUX models on Apple Silicon, with per-variant benchmark notes.
+- [mlx-taef](https://github.com/IonDen/mlx-taef): TAESD/TAEF tiny autoencoders in MLX for fast diffusion latent previews and low-memory decode on Apple Silicon.
 
 ## Demo
 


### PR DESCRIPTION
Thanks for maintaining this list! Adding two MLX diffusion tools for Apple Silicon, both of which integrate with [mflux](https://github.com/filipstrand/mflux):

- **mlx-teacache** — TeaCache step-skipping wrapper for FLUX models, with honest per-variant benchmark notes.
- **mlx-taef** — TAESD/TAEF tiny autoencoders for fast latent previews and low-memory FLUX decode.

Added both to **Libraries and Tools**, matching the existing `- [name](url): desc.` format. Please feel free to reword, move, or close if they're not a fit.