### PR TITLE
Add mlx-sparse to Libraries and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ An awesome list dedicated to the [MLX library](https://github.com/ml-explore/mlx
 - [docker_mlx_cpp](https://github.com/RobotFlow-Labs/docker_mlx_cpp) - The NVIDIA Container Toolkit for Mac. Give any Docker container full Metal GPU access. 107+ GPU operations via MLX.
 - [mlx-teacache](https://github.com/IonDen/mlx-teacache): TeaCache step-skipping wrapper for mflux FLUX models on Apple Silicon, with per-variant benchmark notes.
 - [mlx-taef](https://github.com/IonDen/mlx-taef): TAESD/TAEF tiny autoencoders in MLX for fast diffusion latent previews and low-memory decode on Apple Silicon.
+- [mlx-sparse](https://github.com/waleed-sh/mlx-sparse): Sparse array containers, primitives and linear algebra for MLX.
 
 ## Demo
 


### PR DESCRIPTION
Adds [mlx-sparse](https://github.com/waleed-sh/mlx-sparse) to Libraries and Tools section.

`mlx-sparse` provides early support for sparse arrays in MLX, including COO, CSR, and CSC containers, sparse primitives and operations, some sparse linear algebra routines, and initial autodiff support. 

Core operations are implemented using native C++ and Metal kernels, with Accelerate-backed paths on macOS where applicable. It currently supports Linux as CPU-only and macOS on CPU and Metal where available.