### PR TITLE
Add MacProvider to Libraries and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ An awesome list dedicated to the [MLX library](https://github.com/ml-explore/mlx
 - [mlx-teacache](https://github.com/IonDen/mlx-teacache): TeaCache step-skipping wrapper for mflux FLUX models on Apple Silicon, with per-variant benchmark notes.
 - [mlx-taef](https://github.com/IonDen/mlx-taef): TAESD/TAEF tiny autoencoders in MLX for fast diffusion latent previews and low-memory decode on Apple Silicon.
 - [mlx-sparse](https://github.com/waleed-sh/mlx-sparse): Sparse array containers, primitives and linear algebra for MLX.
+- [MacProvider](https://github.com/Augustas11/macprovider): Coordinator + gateway that turns any Apple Silicon Mac into a remote-addressable mlx-lm endpoint. OpenAI-compatible API, outbound-WebSocket provider daemon (no port-forwarding), and signed receipts binding (prompt, output, provider) for verifiable inference.
 
 ## Demo
 


### PR DESCRIPTION
Adds MacProvider to **Libraries and Tools**.

MacProvider is a thin coordinator + gateway over `mlx-lm` that turns any Apple Silicon Mac into a remote-addressable inference endpoint:

- Provider daemon registers via outbound WebSocket — no port-forwarding required on the Mac
- Gateway exposes a single OpenAI-compatible `/v1/chat/completions` URL across the pool
- Every response is returned with a signed receipt binding (prompt hash, output hash, provider identity) for verifiable inference

Sits alongside the existing OpenAI-compatible MLX server entries (Rapid-MLX, mlx-omni-server, mlx-local-server, AutoMLX) — adds the "make it remotely addressable + verifiable" layer rather than replacing them.

Repo: https://github.com/Augustas11/macprovider
Built on `mlx-lm`. Apple Silicon only (M1+, macOS 14+).
