### PR TITLE
feat: add TWZRD Agent Intel MCP server to Libraries and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ An awesome list dedicated to the [MLX library](https://github.com/ml-explore/mlx
 - [mlx-teacache](https://github.com/IonDen/mlx-teacache): TeaCache step-skipping wrapper for mflux FLUX models on Apple Silicon, with per-variant benchmark notes.
 - [mlx-taef](https://github.com/IonDen/mlx-taef): TAESD/TAEF tiny autoencoders in MLX for fast diffusion latent previews and low-memory decode on Apple Silicon.
 - [mlx-sparse](https://github.com/waleed-sh/mlx-sparse): Sparse array containers, primitives and linear algebra for MLX.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for AI agent wallets on Solana. Verify agent identity before x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ## Demo
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the Libraries and Tools section — a trust scoring MCP server for AI agent wallets on Solana, callable from any MLX-powered agent or tool via Model Context Protocol.

**What it does:**
- `score_agent(wallet)` — returns trust score, behavior metrics, and risk flags for a Solana agent wallet
- `preflight_check(wallet)` — quick safety check before executing an x402 micropayment
- `get_trust_receipt(wallet)` — paid endpoint (x402 micropayment) returning a signed trust attestation

**Why it fits here:**
As MLX-based agents on Apple Silicon increasingly participate in autonomous workflows and pay-per-use APIs (x402 protocol), verifying counterparty wallet trust before committing SOL/USDC becomes useful. The MCP endpoint integrates directly with any agent that supports streamable-http MCP.

**Config:**
```json
{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}
```

Live endpoint: https://intel.twzrd.xyz/mcp