### PR TITLE
Add mlx-local-server — Rust OpenAI-compatible inference server (LLM + image + audio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ An awesome list dedicated to the [MLX library](https://github.com/ml-explore/mlx
 - [AutoMLX](https://github.com/wsvn53/AutoMLX): An easy-to-use LLMs inference tool for quickly loading models accelerated by the Apple MLX framework on Mac devices, and providing a simple and compatible API interface for integration with other LLMs tools.
 - [mlx-omni-server](https://github.com/madroidmaq/mlx-omni-server): MLX Omni Server is a local inference server powered by Apple's MLX framework, specifically designed for Apple Silicon (M-series) chips. It implements OpenAI-compatible API endpoints, enabling seamless integration with existing OpenAI SDK clients while leveraging the power of local ML inference.
 - [Rapid-MLX](https://github.com/raullenchai/Rapid-MLX): OpenAI-compatible LLM inference server for Apple Silicon. 2-4x faster than Ollama with full tool calling, reasoning separation, and prompt caching.
+- [mlx-local-server](https://github.com/Ar9av/mlx-lm-server): OpenAI-compatible inference servers for Apple Silicon built in Rust — covers LLM (chat, embeddings, vision, LoRA, fine-tuning), image generation (FLUX.2-klein, 9s/image), and audio (TTS, STT, source separation). 8MB idle RAM, 16ms cold start.
 
 - [docker_mlx_cpp](https://github.com/RobotFlow-Labs/docker_mlx_cpp) - The NVIDIA Container Toolkit for Mac. Give any Docker container full Metal GPU access. 107+ GPU operations via MLX.
 - [mlx-teacache](https://github.com/IonDen/mlx-teacache): TeaCache step-skipping wrapper for mflux FLUX models on Apple Silicon, with per-variant benchmark notes.


### PR DESCRIPTION
## What

Adds [mlx-local-server](https://github.com/Ar9av/mlx-lm-server) to the Libraries and Tools section.

## About the project

OpenAI-compatible inference servers for Apple Silicon, written in Rust with MLX (via PyO3) for inference. Three servers in one repo:

- **LLM**: chat completions, embeddings, vision, LoRA hot-swap, speculative decoding, fine-tuning
- **Image**: FLUX.2-klein-4B text-to-image (~9s/image on M-series, 4GB on disk)
- **Audio**: TTS (Kokoro), STT (Whisper), source separation

Key stats: 8MB idle RAM, 16ms cold start, single binary per server.

Showcased at WWDC 2025 — Build local AI agents on Mac with MLX.